### PR TITLE
Implement getEntityFromData methods on the env api instead of the space api.

### DIFF
--- a/lib/create-environment-api.js
+++ b/lib/create-environment-api.js
@@ -898,7 +898,77 @@ export default function createEnvironmentApi ({
     }
   }
 
+  /**
+   * Creates SDK Entry object (locally) from entry data
+   * @memberof ContentfulSpaceAPI
+   * @param {object} entryData - Entry Data
+   * @return {Entry.Entry} Entry
+   * @example
+   * space.getEntry('entryId').then(entry => {
+   *
+   *   // Build a plainObject in order to make it usable for React (saving in state or redux)
+   *   const plainObject = entry.toPlainObject();
+   *
+   *   // The entry is being updated in some way as plainObject:
+   *   const updatedPlainObject = {
+   *     ...plainObject,
+   *     fields: {
+   *       ...plainObject.fields,
+   *       title: {
+   *         'en-US': 'updatedTitle'
+   *       }
+   *     }
+   *   };
+   *
+   *   // Rebuild an sdk object out of the updated plainObject:
+   *   const entryWithMethodsAgain = space.getEntryFromData(updatedPlainObject);
+   *
+   *   // Update with help of the sdk method:
+   *   entryWithMethodsAgain.update();
+   *
+   * });
+   **/
+  function getEntryFromData (entryData) {
+    return wrapEntry(http, entryData)
+  }
+
+  /**
+   * Creates SDK Asset object (locally) from entry data
+   * @memberof ContentfulSpaceAPI
+   * @param {object} entryData - Asset ID
+   * @return {Asset.Asset} Asset
+   * @example
+   * space.getAsset('asset_id').then(asset => {
+   *
+   *   // Build a plainObject in order to make it usable for React (saving in state or redux)
+   *   const plainObject = asset.toPlainObject();
+   *
+   *   // The asset is being updated in some way as plainObject:
+   *   const updatedPlainObject = {
+   *     ...plainObject,
+   *     fields: {
+   *       ...plainObject.fields,
+   *       title: {
+   *         'en-US': 'updatedTitle'
+   *       }
+   *     }
+   *   };
+   *
+   *   // Rebuild an sdk object out of the updated plainObject:
+   *   const assetWithMethodsAgain = space.getAssetFromData(updatedPlainObject);
+   *
+   *   // Update with help of the sdk method:
+   *   assetWithMethodsAgain.update();
+   *
+   * });
+  */
+  function getAssetFromData (assetData) {
+    return wrapAsset(http, assetData)
+  }
+
   return {
+    getEntryFromData,
+    getAssetFromData,
     delete: deleteEnvironment,
     update: updateEnvironment,
     getContentType: getContentType,

--- a/lib/create-environment-api.js
+++ b/lib/create-environment-api.js
@@ -900,11 +900,11 @@ export default function createEnvironmentApi ({
 
   /**
    * Creates SDK Entry object (locally) from entry data
-   * @memberof ContentfulSpaceAPI
+   * @memberof ContentfulEnvironmentAPI
    * @param {object} entryData - Entry Data
    * @return {Entry.Entry} Entry
    * @example
-   * space.getEntry('entryId').then(entry => {
+   * environment.getEntry('entryId').then(entry => {
    *
    *   // Build a plainObject in order to make it usable for React (saving in state or redux)
    *   const plainObject = entry.toPlainObject();
@@ -921,7 +921,7 @@ export default function createEnvironmentApi ({
    *   };
    *
    *   // Rebuild an sdk object out of the updated plainObject:
-   *   const entryWithMethodsAgain = space.getEntryFromData(updatedPlainObject);
+   *   const entryWithMethodsAgain = environment.getEntryFromData(updatedPlainObject);
    *
    *   // Update with help of the sdk method:
    *   entryWithMethodsAgain.update();
@@ -934,11 +934,11 @@ export default function createEnvironmentApi ({
 
   /**
    * Creates SDK Asset object (locally) from entry data
-   * @memberof ContentfulSpaceAPI
+   * @memberof ContentfulEnvironmentAPI
    * @param {object} entryData - Asset ID
    * @return {Asset.Asset} Asset
    * @example
-   * space.getAsset('asset_id').then(asset => {
+   * environment.getAsset('asset_id').then(asset => {
    *
    *   // Build a plainObject in order to make it usable for React (saving in state or redux)
    *   const plainObject = asset.toPlainObject();
@@ -955,13 +955,14 @@ export default function createEnvironmentApi ({
    *   };
    *
    *   // Rebuild an sdk object out of the updated plainObject:
-   *   const assetWithMethodsAgain = space.getAssetFromData(updatedPlainObject);
+   *   const assetWithMethodsAgain = environment.getAssetFromData(updatedPlainObject);
    *
    *   // Update with help of the sdk method:
    *   assetWithMethodsAgain.update();
    *
    * });
   */
+
   function getAssetFromData (assetData) {
     return wrapAsset(http, assetData)
   }

--- a/lib/create-space-api.js
+++ b/lib/create-space-api.js
@@ -1604,77 +1604,7 @@ export default function createSpaceApi ({
     }
   }
 
-  /**
-   * Creates SDK Entry object (locally) from entry data
-   * @memberof ContentfulSpaceAPI
-   * @param {object} entryData - Entry Data
-   * @return {Entry.Entry} Entry
-   * @example
-   * space.getEntry('entryId').then(entry => {
-   *
-   *   // Build a plainObject in order to make it usable for React (saving in state or redux)
-   *   const plainObject = entry.toPlainObject();
-   *
-   *   // The entry is being updated in some way as plainObject:
-   *   const updatedPlainObject = {
-   *     ...plainObject,
-   *     fields: {
-   *       ...plainObject.fields,
-   *       title: {
-   *         'en-US': 'updatedTitle'
-   *       }
-   *     }
-   *   };
-   *
-   *   // Rebuild an sdk object out of the updated plainObject:
-   *   const entryWithMethodsAgain = space.getEntryFromData(updatedPlainObject);
-   *
-   *   // Update with help of the sdk method:
-   *   entryWithMethodsAgain.update();
-   *
-   * });
-   **/
-  function getEntryFromData (entryData) {
-    return wrapEntry(http, entryData)
-  }
-
-  /**
-   * Creates SDK Asset object (locally) from entry data
-   * @memberof ContentfulSpaceAPI
-   * @param {object} entryData - Asset ID
-   * @return {Asset.Asset} Asset
-   * @example
-   * space.getAsset('asset_id').then(asset => {
-   *
-   *   // Build a plainObject in order to make it usable for React (saving in state or redux)
-   *   const plainObject = asset.toPlainObject();
-   *
-   *   // The asset is being updated in some way as plainObject:
-   *   const updatedPlainObject = {
-   *     ...plainObject,
-   *     fields: {
-   *       ...plainObject.fields,
-   *       title: {
-   *         'en-US': 'updatedTitle'
-   *       }
-   *     }
-   *   };
-   *
-   *   // Rebuild an sdk object out of the updated plainObject:
-   *   const assetWithMethodsAgain = space.getAssetFromData(updatedPlainObject);
-   *
-   *   // Update with help of the sdk method:
-   *   assetWithMethodsAgain.update();
-   *
-   * });
-  */
-  function getAssetFromData (assetData) {
-    return wrapAsset(http, assetData)
-  }
-
   return {
-    getEntryFromData,
-    getAssetFromData,
     delete: deleteSpace,
     update: updateSpace,
     getEnvironment,

--- a/test/unit/create-environment-api-test.js
+++ b/test/unit/create-environment-api-test.js
@@ -21,8 +21,11 @@ import {
   makeGetCollectionTest,
   makeCreateEntityTest,
   makeCreateEntityWithIdTest,
-  makeEntityMethodFailingTest
+  makeEntityMethodFailingTest,
+  testGettingEntrySDKObject
 } from './test-creators/static-entity-methods'
+import { wrapEntry } from '../../lib/entities/entry'
+import { wrapAsset } from '../../lib/entities/asset'
 
 function setup (promise) {
   const entitiesMock = setupEntitiesMock(createEnvironmentApiRewireApi)
@@ -182,6 +185,18 @@ test('API call getEntry', (t) => {
   })
 })
 
+test('GetSDKEntry from data', (t) => {
+  const expectedFunctions = ['toPlainObject', 'update', 'delete', 'publish', 'unpublish', 'archive', 'unarchive', 'isPublished', 'isUpdated', 'isDraft', 'isArchived']
+  testGettingEntrySDKObject(t, setup, {
+    type: 'entry',
+    wrapFunctionName: 'wrapEntry',
+    resourceMock: entryMock,
+    wrapFunction: wrapEntry,
+    expectedFunctions: expectedFunctions,
+    getResourceFromDataFunctionName: 'getEntryFromData'
+  })
+})
+
 test('API call getEntry fails', (t) => {
   makeEntityMethodFailingTest(t, setup, teardown, {
     methodToTest: 'getEntry'
@@ -250,6 +265,18 @@ test('API call getAsset', (t) => {
     entityType: 'asset',
     mockToReturn: assetMock,
     methodToTest: 'getAsset'
+  })
+})
+
+test('GetSDKAsset from data', (t) => {
+  const expectedFunctions = ['processForLocale', 'processForAllLocales', 'toPlainObject', 'update', 'delete', 'publish', 'unpublish', 'archive', 'unarchive']
+  testGettingEntrySDKObject(t, setup, {
+    type: 'asset',
+    wrapFunctionName: 'wrapAsset',
+    resourceMock: assetMock,
+    wrapFunction: wrapAsset,
+    expectedFunctions: expectedFunctions,
+    getResourceFromDataFunctionName: 'getAssetFromData'
   })
 })
 

--- a/test/unit/create-space-api-test.js
+++ b/test/unit/create-space-api-test.js
@@ -26,11 +26,8 @@ import {
   makeGetCollectionTest,
   makeCreateEntityTest,
   makeCreateEntityWithIdTest,
-  makeEntityMethodFailingTest,
-  testGettingEntrySDKObject
+  makeEntityMethodFailingTest
 } from './test-creators/static-entity-methods'
-import { wrapEntry } from '../../lib/entities/entry'
-import { wrapAsset } from '../../lib/entities/asset'
 
 function setup (promise) {
   const entitiesMock = setupEntitiesMock(createSpaceApiRewireApi)
@@ -190,18 +187,6 @@ test('API call getEntry', (t) => {
   })
 })
 
-test('GetSDKEntry from data', (t) => {
-  const expectedFunctions = ['toPlainObject', 'update', 'delete', 'publish', 'unpublish', 'archive', 'unarchive', 'isPublished', 'isUpdated', 'isDraft', 'isArchived']
-  testGettingEntrySDKObject(t, setup, {
-    type: 'entry',
-    wrapFunctionName: 'wrapEntry',
-    resourceMock: entryMock,
-    wrapFunction: wrapEntry,
-    expectedFunctions: expectedFunctions,
-    getResourceFromDataFunctionName: 'getEntryFromData'
-  })
-})
-
 test('API call getEntry fails', (t) => {
   makeEntityMethodFailingTest(t, setup, teardown, {
     methodToTest: 'getEntry'
@@ -270,18 +255,6 @@ test('API call getAsset', (t) => {
     entityType: 'asset',
     mockToReturn: assetMock,
     methodToTest: 'getAsset'
-  })
-})
-
-test('GetSDKAsset from data', (t) => {
-  const expectedFunctions = ['processForLocale', 'processForAllLocales', 'toPlainObject', 'update', 'delete', 'publish', 'unpublish', 'archive', 'unarchive']
-  testGettingEntrySDKObject(t, setup, {
-    type: 'asset',
-    wrapFunctionName: 'wrapAsset',
-    resourceMock: assetMock,
-    wrapFunction: wrapAsset,
-    expectedFunctions: expectedFunctions,
-    getResourceFromDataFunctionName: 'getAssetFromData'
   })
 })
 


### PR DESCRIPTION
This would be my suggestion on how `getEntryFromData` and `getAssetFromData` could be implemented on the environment api instead.